### PR TITLE
Add --version flag with build stamp support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,11 @@ limitations under the License.
 
 # LGTMCP - AI Code Review via MCP
 
-**IMPORTANT**: Update this file after completing any task to document changes.
+**IMPORTANT**:
+
+1. Update this file after completing any task to document changes.
+2. After completing any task, run `make lint`, `make test`, then use `mcp__lgtmcp__review_only` to review changes.
+3. Do not use conventional commit prefixes (feat:, fix:, docs:, etc.) in commit messages.
 
 ## Overview
 
@@ -86,12 +90,23 @@ prompts:
 ```bash
 make test    # Run tests
 make coverage # Run tests with coverage (77.4%)
-make build   # Build binary
+make build   # Build binary (VERSION=x.y.z for custom version)
 make lint    # Run golangci-lint
 make fmt     # Format code with gofumpt
 make clean   # Remove build artifacts
 make deps    # Install tools and dependencies
 ```
+
+### Version Information
+
+The binary supports a `--version` flag that displays:
+
+- Version (defaults to "dev", set via `VERSION` during build)
+- Git commit hash (automatically detected)
+- Dirty status (if working tree has uncommitted changes)
+- OS/Architecture
+
+Example: `lgtmcp --version` outputs `lgtmcp version 1.0.0 (ef22d19, darwin/arm64)`
 
 ### Tool Management
 
@@ -106,6 +121,10 @@ Tools (golangci-lint v2.4.0, gofumpt v0.8.0) are managed separately in `tools/` 
 - **Lint check**: `make lint`
 - **Format code**: `make fmt`
 - **Run with lefthook**: `lefthook run pre-commit`
+- **Code review**: After completing any task:
+  1. Run `make lint` to check for lint errors
+  2. Run `make test` to ensure all tests pass
+  3. Use `mcp__lgtmcp__review_only` to review your changes
 
 ## Testing Coverage
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ GOFUMPT=bin/gofumpt
 GOLINT=bin/golangci-lint
 
 # Build flags
-LDFLAGS=-ldflags "-s -w"
+VERSION?=dev
+LDFLAGS=-ldflags "-s -w -X 'github.com/shields/lgtmcp/internal/version.Version=$(VERSION)'"
 
 # Default target
 all: deps fmt lint test build

--- a/cmd/lgtmcp/main.go
+++ b/cmd/lgtmcp/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/shields/lgtmcp/internal/config"
 	"github.com/shields/lgtmcp/internal/logging"
+	"github.com/shields/lgtmcp/internal/version"
 	mcpserver "github.com/shields/lgtmcp/pkg/mcp"
 )
 
@@ -32,6 +34,16 @@ func main() {
 }
 
 func run() int {
+	// Parse command-line flags.
+	versionFlag := flag.Bool("version", false, "Show version information")
+	flag.Parse()
+
+	// Handle version flag.
+	if *versionFlag {
+		_, _ = fmt.Fprintln(os.Stdout, version.String()) //nolint:errcheck // Version output to stdout is not critical
+		return 0
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,92 @@
+// Copyright © 2025 Michael Shields
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version provides version information for the application.
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
+// Version is set via ldflags during build.
+var Version = "dev"
+
+// String returns a formatted version string.
+func String() string {
+	commit := "unknown"
+	modified := false
+
+	// Get commit from build info if available
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if setting.Value != "" {
+					commit = setting.Value
+					if len(commit) > 7 {
+						commit = commit[:7]
+					}
+				}
+			case "vcs.modified":
+				modified = setting.Value == "true"
+			default:
+				// Ignore other build settings
+			}
+		}
+	}
+
+	if modified {
+		commit += "-dirty"
+	}
+
+	return fmt.Sprintf("lgtmcp version %s (%s, %s/%s)",
+		Version, commit, runtime.GOOS, runtime.GOARCH)
+}
+
+// DetailedString returns a detailed version string including build info.
+func DetailedString() string {
+	info := fmt.Sprintf("lgtmcp version %s\n", Version)
+	info += fmt.Sprintf("  Go:       %s\n", runtime.Version())
+	info += fmt.Sprintf("  OS/Arch:  %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+	// Add module and VCS information if available
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		if buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
+			info += fmt.Sprintf("  Module:   %s\n", buildInfo.Main.Version)
+		}
+
+		for _, setting := range buildInfo.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if setting.Value != "" {
+					info += fmt.Sprintf("  Commit:   %s\n", setting.Value)
+				}
+			case "vcs.time":
+				if setting.Value != "" {
+					info += fmt.Sprintf("  VCS Time: %s\n", setting.Value)
+				}
+			case "vcs.modified":
+				if setting.Value == "true" {
+					info += "  Modified: true\n"
+				}
+			default:
+				// Ignore other build settings
+			}
+		}
+	}
+
+	return info
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,133 @@
+// Copyright © 2025 Michael Shields
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/shields/lgtmcp/internal/version"
+)
+
+func TestString(t *testing.T) { //nolint:paralleltest // Modifies global Version variable
+	// Save original version
+	originalVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = originalVersion
+	})
+
+	tests := []struct {
+		name             string
+		version          string
+		expectedContains []string
+	}{
+		{
+			name:    "default dev version",
+			version: "dev",
+			expectedContains: []string{
+				"lgtmcp version dev",
+				runtime.GOOS + "/" + runtime.GOARCH,
+			},
+		},
+		{
+			name:    "custom version",
+			version: "1.2.3",
+			expectedContains: []string{
+				"lgtmcp version 1.2.3",
+				runtime.GOOS + "/" + runtime.GOARCH,
+			},
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // Cannot parallelize due to global state
+		t.Run(tt.name, func(t *testing.T) {
+			version.Version = tt.version
+			result := version.String()
+
+			for _, expected := range tt.expectedContains {
+				if !strings.Contains(result, expected) {
+					t.Errorf("String() = %q, want it to contain %q", result, expected)
+				}
+			}
+
+			// Should have commit info (either from git or "unknown")
+			if !strings.Contains(result, "(") || !strings.Contains(result, ")") {
+				t.Errorf("String() = %q, want it to have commit info in parentheses", result)
+			}
+		})
+	}
+}
+
+func TestDetailedString(t *testing.T) { //nolint:paralleltest // Modifies global Version variable
+	// Save original version
+	originalVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = originalVersion
+	})
+
+	tests := []struct {
+		name             string
+		version          string
+		expectedContains []string
+	}{
+		{
+			name:    "default dev version",
+			version: "dev",
+			expectedContains: []string{
+				"lgtmcp version dev",
+				"Go:",
+				"OS/Arch:",
+				runtime.Version(),
+				runtime.GOOS + "/" + runtime.GOARCH,
+			},
+		},
+		{
+			name:    "custom version",
+			version: "2.0.0-beta",
+			expectedContains: []string{
+				"lgtmcp version 2.0.0-beta",
+				"Go:",
+				"OS/Arch:",
+			},
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // Cannot parallelize due to global state
+		t.Run(tt.name, func(t *testing.T) {
+			version.Version = tt.version
+			result := version.DetailedString()
+
+			for _, expected := range tt.expectedContains {
+				if !strings.Contains(result, expected) {
+					t.Errorf("DetailedString() = %q, want it to contain %q", result, expected)
+				}
+			}
+
+			// Should be multi-line
+			lines := strings.Split(result, "\n")
+			if len(lines) < 3 {
+				t.Errorf("DetailedString() should return multiple lines, got %d lines", len(lines))
+			}
+		})
+	}
+}
+
+func TestVersionVariable(t *testing.T) { //nolint:paralleltest // Reads global Version variable
+	// Default should be "dev"
+	if version.Version != "dev" {
+		t.Errorf("Version = %q, want %q", version.Version, "dev")
+	}
+}


### PR DESCRIPTION
- Add internal/version package for version information
- Support --version flag to display version, commit, OS/arch
- Use Go's debug.ReadBuildInfo() for automatic git commit detection
- Avoid non-reproducible builds (no timestamps or user info)
- Add VERSION variable to Makefile (defaults to "dev")
- Include comprehensive tests for version package
- Update CLAUDE.md with version documentation and review instructions
