### PR TITLE
Fix make install target to properly install to ~/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ BINARY_PATH=bin/$(BINARY_NAME)
 MAIN_PATH=./cmd/lgtmcp
 COVERAGE_FILE=coverage.out
 COVERAGE_HTML=coverage.html
+INSTALL_PATH?=$(HOME)/bin
 
 # Go commands
 GOCMD=go
@@ -49,7 +50,7 @@ help:
 	@echo "  lint          - Run golangci-lint"
 	@echo "  fmt           - Format code with gofumpt"
 	@echo "  clean         - Remove built binaries and test artifacts"
-	@echo "  install       - Install the binary to GOPATH/bin"
+	@echo "  install       - Install the binary to ~/bin (or INSTALL_PATH)"
 	@echo "  run           - Run the application"
 
 # Install tools locally
@@ -128,9 +129,9 @@ clean:
 
 # Install binary
 install: build
-	@echo "==> Installing $(BINARY_NAME)..."
-	$(GOINSTALL) $(MAIN_PATH)
-	@echo "$(BINARY_NAME) installed to $$GOPATH/bin"
+	@echo "==> Installing $(BINARY_NAME) to $(INSTALL_PATH)..."
+	mkdir -p $(INSTALL_PATH)
+	cp $(BINARY_PATH) $(INSTALL_PATH)/$(BINARY_NAME)
 
 # Run the application
 run: build

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ cd lgtmcp
 make build
 ```
 
+### Install to ~/bin
+
+```bash
+make install
+```
+
+This installs the binary to `~/bin` by default. You can customize the installation directory:
+
+```bash
+make install INSTALL_PATH=/usr/local/bin
+```
+
+**Note**: Ensure `~/bin` is in your shell's `PATH`. Add this to your shell configuration file if needed:
+
+```bash
+# For bash/zsh
+export PATH="$HOME/bin:$PATH"
+```
+
 ### Configuration
 
 1. Get a Google API key from [Google AI Studio](https://aistudio.google.com/apikey).


### PR DESCRIPTION
- Changed install target to copy binary directly to ~/bin instead of using go install
- Added INSTALL_PATH variable (defaults to ~/bin) for customization
- Updated help text to reflect actual installation location
- Made mkdir and cp commands visible for transparency
- Documented the new install target in README.md with PATH setup instructions
