### PR TITLE
Add make tools step to lefthook pre-commit

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -18,6 +18,11 @@
 pre-commit:
   parallel: false
   commands:
+    # Ensure tools are installed before running checks
+    install-tools:
+      run: make tools
+      priority: 1
+
     format-go:
       glob: "**/*.go"
       run: bin/gofumpt -w {staged_files}


### PR DESCRIPTION
Ensure tools are installed before running checks that depend on them.
This prevents failures when bin/gofumpt or bin/golangci-lint are not
yet installed.
